### PR TITLE
Added a check to to see if the COM class exists before loading it.

### DIFF
--- a/src/Stevebauman/Corp/Services/UserComService.php
+++ b/src/Stevebauman/Corp/Services/UserComService.php
@@ -48,7 +48,10 @@ class UserComService {
         /*
          * Construct a new COM object
          */
-        $this->com = new COM($this->ldapComCommand);
+        if (class_exists('COM'))
+        {
+            $this->com = new COM($this->ldapComCommand);
+        }
 
         /*
          * Get configuration details


### PR DESCRIPTION
On Linux systems creating the COM object will throw an exception since it is not a module that is loaded under Linux-based PHP distributions.